### PR TITLE
Adds a trending_towards attribute when period is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ I put a lot of work into making this repo and component available and updated to
 **max**:\
   Maximum value of processed values of source sensors.
 
+**trending_towards**:\
+  The predicted value if monitored entities keep their current states for the remainder of the period. Requires "end" configuration variable to be set to actual end of period and not now().
+
 ## Time periods
 
 The `average` integration will execute a measure within a precise time period. You should provide none, only `duration` (when period ends at now) or exactly 2 of the following:

--- a/custom_components/average/const.py
+++ b/custom_components/average/const.py
@@ -1,5 +1,4 @@
-"""
-The Average Sensor.
+"""The Average Sensor.
 
 For more details about this sensor, please refer to the documentation at
 https://github.com/Limych/ha-average/
@@ -50,6 +49,7 @@ ATTR_AVAILABLE_SOURCES: Final = "available_sources"
 ATTR_COUNT: Final = "count"
 ATTR_MIN_VALUE: Final = "min_value"
 ATTR_MAX_VALUE: Final = "max_value"
+ATTR_TRENDING_TOWARDS: Final = "trending_towards"
 #
 ATTR_TO_PROPERTY: Final = [
     ATTR_START,
@@ -60,6 +60,7 @@ ATTR_TO_PROPERTY: Final = [
     ATTR_COUNT,
     ATTR_MAX_VALUE,
     ATTR_MIN_VALUE,
+    ATTR_TRENDING_TOWARDS,
 ]
 
 

--- a/custom_components/average/sensor.py
+++ b/custom_components/average/sensor.py
@@ -168,6 +168,7 @@ class AverageSensor(SensorEntity):
         self._precision = precision
         self._undef = undef
         self._temperature_mode = None
+        self._actual_end = None
 
         self.sources = expand_entity_ids(hass, entity_ids)
         self.count_sources = len(self.sources)
@@ -524,7 +525,6 @@ class AverageSensor(SensorEntity):
                     last_time = start_ts
                     if item is not None and self._has_state(item.state):
                         last_state = self._get_state_value(item)
-                        current_values.append(last_state)
 
                     # Get the other states
                     for item in history_list.get(entity_id):
@@ -545,6 +545,7 @@ class AverageSensor(SensorEntity):
                         last_elapsed = end_ts - last_time
                         value += last_state * last_elapsed
                         elapsed += last_elapsed
+                        current_values.append(last_state)
 
                     if elapsed:
                         value /= elapsed


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a new trending_towards attribute that has the value of the expected average at the end of the period if the monitored entities keeps their current states. This is calculated by the following script block where current_average is the current average of the monitored entities:

```py
current_average = round(
                sum(current_values) / len(current_values), self._precision
            )
if self._precision < 1:
    current_average = int(current_average)
part_of_period = (now_ts - start_ts) / (actual_end_ts - start_ts)
to_now = self._attr_native_value * part_of_period
to_end = current_average * (1 - part_of_period)
self.trending_towards = to_now + to_end
```

This new attribute can be used to predict what the resulting average of this period will be or in my case to programmatically limit my power usage below a limit i have set by using automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
- platform: average
  name: Average power this hour
  entities:
    - sensor.emi_power
  start: "{{ now().replace(minute=0, second=0, microsecond=0) }}"
  end: "{{ now().replace(minute=59, second=59, microsecond=999) }}"
  unique_id: "average_power_h_hacs-2024-01"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #215

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
